### PR TITLE
Add git-native terminology toggle

### DIFF
--- a/docs-static-site/src/content/docs/user-guide/concepts.md
+++ b/docs-static-site/src/content/docs/user-guide/concepts.md
@@ -9,6 +9,8 @@ Understanding the concepts laid out here will help you understand how to use the
 
 Note: if you are already knowledgeable in git, just review git term next to each heading to familiarize yourself with the terminology mapping, and you'll be ready to rock and roll.
 
+Prefer the git terms everywhere? Enable **Edit → Preferences → History → Terminology → "Use git terminology"** to relabel the interface (Iteration → Commit, Project → Repository, Reviewed → Staged, and so on). Restart FreeCAD for the change to apply to every label.
+
 ## FreeCAD Terminology
 
 FreeCAD stores files in the `.FCStd` format, and represents a single **Document**. From the workbench's perspective, a FreeCAD "Document" and "file" mean the same thing.

--- a/freecad/history_wb/application/actions/result_models.py
+++ b/freecad/history_wb/application/actions/result_models.py
@@ -70,6 +70,7 @@ class DiffIssues:
         """Return True when any issue exists on either side or general bucket."""
         return self.old_snapshot is not None or self.new_snapshot is not None or bool(self.general)
 
+
 @dataclass(frozen=True)
 class DocumentDiffResult:
     """Application-level diff result for one FCStd document."""

--- a/freecad/history_wb/domain/settings/repository.py
+++ b/freecad/history_wb/domain/settings/repository.py
@@ -59,6 +59,19 @@ class SettingsRepository(Protocol):
         """
         ...
 
+    def git_terminology_enabled(self) -> bool:
+        """Return whether the git-native terminology display toggle is on.
+
+        Controls whether the UI relabels CAD-friendly vocabulary (Iteration,
+        Project, Reviewed, ...) with the underlying git terms (Commit,
+        Repository, Staged, ...). Independent of diff computation.
+        """
+        ...
+
+    def set_git_terminology_enabled(self, enabled: bool) -> None:
+        """Persist the git-native terminology display toggle."""
+        ...
+
 
 class SettingsPersistenceRepository(Protocol):
     """Interface for raw diff settings persistence state access."""

--- a/freecad/history_wb/entrypoints/commands.py
+++ b/freecad/history_wb/entrypoints/commands.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, TypedDict
 
 from ..qt import QtCore
 from ..resources import ICONPATH
-from ..utils import Log, translate
+from ..utils import Log, term, translate
 
 
 if TYPE_CHECKING:
@@ -92,8 +92,14 @@ class _CommitCommand:
     def GetResources(self) -> CommandResources:
         """Return FreeCAD command metadata for UI integration."""
         return {
-            "MenuText": QtCore.QT_TRANSLATE_NOOP("HistoryCommit", "Save Iteration"),
-            "ToolTip": QtCore.QT_TRANSLATE_NOOP("HistoryCommit", "Save reviewed changes as an iteration"),
+            "MenuText": term(
+                QtCore.QT_TRANSLATE_NOOP("HistoryCommit", "Save Iteration"),
+                QtCore.QT_TRANSLATE_NOOP("HistoryCommit", "Commit"),
+            ),
+            "ToolTip": term(
+                QtCore.QT_TRANSLATE_NOOP("HistoryCommit", "Save reviewed changes as an iteration"),
+                QtCore.QT_TRANSLATE_NOOP("HistoryCommit", "Commit the staged changes"),
+            ),
             "Pixmap": os.path.join(ICONPATH, "Commit.svg"),
         }
 
@@ -117,14 +123,27 @@ class _RefreshRepositoryCommand:
     def GetResources(self) -> CommandResources:
         """Return FreeCAD command metadata for UI integration."""
         return {
-            "MenuText": QtCore.QT_TRANSLATE_NOOP("HistoryRefreshRepository", "Refresh Project"),
-            "ToolTip": QtCore.QT_TRANSLATE_NOOP(
-                "HistoryRefreshRepository",
-                "Refresh the detected project and reload iterations.\n"
-                "Open at least one FreeCAD document "
-                "located within a project before running this command.\n"
-                "How it works: open FreeCAD "
-                "documents are checked one by one until one is found to be located within a project.",
+            "MenuText": term(
+                QtCore.QT_TRANSLATE_NOOP("HistoryRefreshRepository", "Refresh Project"),
+                QtCore.QT_TRANSLATE_NOOP("HistoryRefreshRepository", "Refresh Repository"),
+            ),
+            "ToolTip": term(
+                QtCore.QT_TRANSLATE_NOOP(
+                    "HistoryRefreshRepository",
+                    "Refresh the detected project and reload iterations.\n"
+                    "Open at least one FreeCAD document "
+                    "located within a project before running this command.\n"
+                    "How it works: open FreeCAD "
+                    "documents are checked one by one until one is found to be located within a project.",
+                ),
+                QtCore.QT_TRANSLATE_NOOP(
+                    "HistoryRefreshRepository",
+                    "Refresh the detected repository and reload commits.\n"
+                    "Open at least one FreeCAD document "
+                    "located within a repository before running this command.\n"
+                    "How it works: open FreeCAD "
+                    "documents are checked one by one until one is found to be located within a repository.",
+                ),
             ),
             "Pixmap": os.path.join(ICONPATH, "RefreshRepository.svg"),
         }
@@ -146,10 +165,19 @@ class _InitializeGitRepositoryCommand:
     def GetResources(self) -> CommandResources:
         """Return FreeCAD command metadata for UI integration."""
         return {
-            "MenuText": QtCore.QT_TRANSLATE_NOOP("HistoryInitializeGitRepository", "Initialize Project"),
-            "ToolTip": QtCore.QT_TRANSLATE_NOOP(
-                "HistoryInitializeGitRepository",
-                "Initialize a new project in the selected directory",
+            "MenuText": term(
+                QtCore.QT_TRANSLATE_NOOP("HistoryInitializeGitRepository", "Initialize Project"),
+                QtCore.QT_TRANSLATE_NOOP("HistoryInitializeGitRepository", "Initialize Repository"),
+            ),
+            "ToolTip": term(
+                QtCore.QT_TRANSLATE_NOOP(
+                    "HistoryInitializeGitRepository",
+                    "Initialize a new project in the selected directory",
+                ),
+                QtCore.QT_TRANSLATE_NOOP(
+                    "HistoryInitializeGitRepository",
+                    "Initialize a new repository in the selected directory",
+                ),
             ),
             "Pixmap": os.path.join(ICONPATH, "CreateGitRepository.svg"),
         }
@@ -173,13 +201,25 @@ class _OpenAllDocumentsInRepositoryCommand:
     def GetResources(self) -> CommandResources:
         """Return FreeCAD command metadata for UI integration."""
         return {
-            "MenuText": QtCore.QT_TRANSLATE_NOOP(
-                "HistoryOpenAllDocumentsInRepository",
-                "Open All Documents in Project",
+            "MenuText": term(
+                QtCore.QT_TRANSLATE_NOOP(
+                    "HistoryOpenAllDocumentsInRepository",
+                    "Open All Documents in Project",
+                ),
+                QtCore.QT_TRANSLATE_NOOP(
+                    "HistoryOpenAllDocumentsInRepository",
+                    "Open All Documents in Repository",
+                ),
             ),
-            "ToolTip": QtCore.QT_TRANSLATE_NOOP(
-                "HistoryOpenAllDocumentsInRepository",
-                "Open every .FCStd file found in the project. Useful for generating en masse.",
+            "ToolTip": term(
+                QtCore.QT_TRANSLATE_NOOP(
+                    "HistoryOpenAllDocumentsInRepository",
+                    "Open every .FCStd file found in the project. Useful for generating en masse.",
+                ),
+                QtCore.QT_TRANSLATE_NOOP(
+                    "HistoryOpenAllDocumentsInRepository",
+                    "Open every .FCStd file found in the repository. Useful for generating en masse.",
+                ),
             ),
             "Pixmap": os.path.join(ICONPATH, "OpenAllDocuments.svg"),
         }
@@ -202,8 +242,14 @@ class _OpenAllDocumentsInRepositoryCommand:
         repo = ui_registry.application_state.git_repository
         if repo is None:
             dialog_view.show_warning_message(
-                translate("History", "No Project"),
-                translate("History", "No project detected. Open a FreeCAD document in a project first."),
+                term(
+                    translate("History", "No Project"),
+                    translate("History", "No Repository"),
+                ),
+                term(
+                    translate("History", "No project detected. Open a FreeCAD document in a project first."),
+                    translate("History", "No repository detected. Open a FreeCAD document in a repository first."),
+                ),
             )
             return
 
@@ -216,10 +262,19 @@ class _UpdateGitIgnoreCommand:
     def GetResources(self) -> CommandResources:
         """Return FreeCAD command metadata for UI integration."""
         return {
-            "MenuText": QtCore.QT_TRANSLATE_NOOP("HistoryUpdateGitIgnore", "Edit Ignored Files"),
-            "ToolTip": QtCore.QT_TRANSLATE_NOOP(
-                "HistoryUpdateGitIgnore",
-                "Edit project ignored files list (.gitignore)",
+            "MenuText": term(
+                QtCore.QT_TRANSLATE_NOOP("HistoryUpdateGitIgnore", "Edit Ignored Files"),
+                QtCore.QT_TRANSLATE_NOOP("HistoryUpdateGitIgnore", "Edit .gitignore"),
+            ),
+            "ToolTip": term(
+                QtCore.QT_TRANSLATE_NOOP(
+                    "HistoryUpdateGitIgnore",
+                    "Edit project ignored files list (.gitignore)",
+                ),
+                QtCore.QT_TRANSLATE_NOOP(
+                    "HistoryUpdateGitIgnore",
+                    "Edit repository ignored files list (.gitignore)",
+                ),
             ),
             "Pixmap": os.path.join(ICONPATH, "GitIgnore.svg"),
         }
@@ -314,7 +369,10 @@ class _CloseDiffWindowsCommand:
     def GetResources(self) -> CommandResources:
         """Return FreeCAD command metadata for UI integration."""
         return {
-            "MenuText": QtCore.QT_TRANSLATE_NOOP("HistoryCloseDiffWindows", "Close Comparison Windows"),
+            "MenuText": term(
+                QtCore.QT_TRANSLATE_NOOP("HistoryCloseDiffWindows", "Close Comparison Windows"),
+                QtCore.QT_TRANSLATE_NOOP("HistoryCloseDiffWindows", "Close Diff Windows"),
+            ),
             "ToolTip": QtCore.QT_TRANSLATE_NOOP(
                 "HistoryCloseDiffWindows",
                 "Close every document starting with 'Diff_' without saving",
@@ -339,7 +397,13 @@ class _CloseDiffWindowsCommand:
 
 
 def register_commands() -> None:
-    """Register the Diff Workbench commands with FreeCAD."""
+    """Register the Diff Workbench commands with FreeCAD.
+
+    Command labels resolve the git-terminology toggle inside GetResources via
+    term(), so no wrapper is needed. FreeCAD queries GetResources at Initialize
+    (before the container exists); term() reads the toggle directly from
+    preferences in that case.
+    """
     import FreeCADGui as Gui  # pylint: disable=import-error
 
     Gui.addCommand("HistoryConfigureAuthorCommand", _ConfigureAuthorCommand())

--- a/freecad/history_wb/entrypoints/workbench.py
+++ b/freecad/history_wb/entrypoints/workbench.py
@@ -14,7 +14,7 @@ from typing import cast
 
 from ..qt import QtCore, QtGui, QtWidgets
 from ..resources import ICONPATH
-from ..utils import Log, set_logger, translate
+from ..utils import Log, set_logger, term, translate
 
 
 _PREFERENCES_REGISTRY_ATTR = "_history_wb_preference_pages"
@@ -57,7 +57,13 @@ if Gui is not None:
         def __init__(self):
             super().__init__()
             self.MenuText = cast(str, QtCore.QT_TRANSLATE_NOOP("Workbench", "History"))
-            self.ToolTip = cast(str, QtCore.QT_TRANSLATE_NOOP("Workbench", "Track project iterations and history"))
+            self.ToolTip = cast(
+                str,
+                term(
+                    QtCore.QT_TRANSLATE_NOOP("Workbench", "Track project iterations and history"),
+                    QtCore.QT_TRANSLATE_NOOP("Workbench", "Track repository commits and history"),
+                ),
+            )
             self._subwindow = None  # Store reference to MDI subwindow
 
         def GetClassName(self) -> str:
@@ -232,6 +238,7 @@ if Gui is not None:
 
             # Clear panel-scoped presenters; application state survives for command access
             from ..ui.registry import ui_registry
+
             ui_registry.clear_presenters()
 
         def _focus_diff_panel_deferred(self) -> None:

--- a/freecad/history_wb/infrastructure/freecad/settings_repo.py
+++ b/freecad/history_wb/infrastructure/freecad/settings_repo.py
@@ -41,6 +41,25 @@ class _ParamGroup(Protocol):
 MIN_FLOAT_PRECISION = 0
 MAX_FLOAT_PRECISION = 12
 
+# Single source of truth for where the History workbench preferences live.
+PARAM_GROUP_PATH = "User parameter:BaseApp/Preferences/Mod/History"
+KEY_GIT_TERMINOLOGY = "GitTerminology"
+
+
+def read_git_terminology_enabled() -> bool:
+    """Read the git-terminology toggle directly from FreeCAD preferences.
+
+    Used during command registration, which happens at workbench Initialize
+    before the application container (and its cached settings repository)
+    exists. Returns False when FreeCAD is unavailable (e.g. unit tests).
+    """
+    try:
+        import FreeCAD as App  # pylint: disable=import-error
+
+        return bool(App.ParamGet(PARAM_GROUP_PATH).GetBool(KEY_GIT_TERMINOLOGY, False))
+    except (ImportError, AttributeError):
+        return False
+
 
 class FreeCADSettingsRepository:
     """Settings repository implementation using FreeCAD's Parameter system.
@@ -67,8 +86,9 @@ class FreeCADSettingsRepository:
 
     def __init__(self, ctx: FreeCadContext) -> None:
         self._ctx = ctx
-        self._group_path = "User parameter:BaseApp/Preferences/Mod/History"
+        self._group_path = PARAM_GROUP_PATH
         self._cached_settings: Settings | None = None
+        self._cached_git_terminology: bool | None = None
 
     def _get_group(self) -> _ParamGroup:
         return cast(_ParamGroup, self._ctx.app.ParamGet(self._group_path))
@@ -232,3 +252,15 @@ class FreeCADSettingsRepository:
             self._cached_settings = self._build_settings_from_state(self.get_persistence_state())
 
         return self._cached_settings
+
+    def git_terminology_enabled(self) -> bool:
+        """Return the git-terminology display toggle, caching the lookup."""
+        if self._cached_git_terminology is None:
+            self._cached_git_terminology = self._get_group().GetBool(KEY_GIT_TERMINOLOGY, False)
+
+        return self._cached_git_terminology
+
+    def set_git_terminology_enabled(self, enabled: bool) -> None:
+        """Persist the git-terminology display toggle and refresh the cache."""
+        self._get_group().SetBool(KEY_GIT_TERMINOLOGY, enabled)
+        self._cached_git_terminology = enabled

--- a/freecad/history_wb/resources/translations/History.ts
+++ b/freecad/history_wb/resources/translations/History.ts
@@ -4,67 +4,110 @@
 <context>
     <name>History</name>
     <message>
-        <location filename="../../entrypoints/commands.py" line="205"/>
+        <location filename="../../entrypoints/commands.py" line="246"/>
         <location filename="../../ui/presenters/workbench_command_presenter.py" line="134"/>
-        <location filename="../../ui/presenters/workbench_command_presenter.py" line="150"/>
-        <location filename="../../ui/presenters/workbench_command_presenter.py" line="170"/>
+        <location filename="../../ui/presenters/workbench_command_presenter.py" line="153"/>
+        <location filename="../../ui/presenters/workbench_command_presenter.py" line="176"/>
         <source>No Project</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../entrypoints/commands.py" line="247"/>
+        <location filename="../../ui/presenters/workbench_command_presenter.py" line="134"/>
+        <location filename="../../ui/presenters/workbench_command_presenter.py" line="153"/>
+        <location filename="../../ui/presenters/workbench_command_presenter.py" line="176"/>
+        <source>No Repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../entrypoints/commands.py" line="251"/>
+        <location filename="../../ui/presenters/workbench_command_presenter.py" line="137"/>
+        <location filename="../../ui/presenters/workbench_command_presenter.py" line="156"/>
+        <location filename="../../ui/presenters/workbench_command_presenter.py" line="179"/>
+        <source>No repository detected. Open a FreeCAD document in a repository first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../ui/presenters/git_repository/author_configuration_handler.py" line="68"/>
-        <location filename="../../ui/presenters/git_repository/author_configuration_handler.py" line="84"/>
-        <location filename="../../ui/presenters/git_repository/commit_iteration_handler.py" line="88"/>
+        <location filename="../../ui/presenters/git_repository/author_configuration_handler.py" line="87"/>
+        <location filename="../../ui/presenters/git_repository/commit_iteration_handler.py" line="94"/>
         <source>Save Iteration Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../ui/presenters/git_repository/author_configuration_handler.py" line="69"/>
+        <location filename="../../ui/presenters/git_repository/author_configuration_handler.py" line="68"/>
+        <location filename="../../ui/presenters/git_repository/author_configuration_handler.py" line="87"/>
+        <location filename="../../ui/presenters/git_repository/commit_iteration_handler.py" line="94"/>
+        <source>Commit Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../ui/presenters/git_repository/author_configuration_handler.py" line="70"/>
         <source>Name and email are required to save iteration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../ui/presenters/git_repository/author_configuration_handler.py" line="85"/>
+        <location filename="../../ui/presenters/git_repository/author_configuration_handler.py" line="71"/>
+        <source>Name and email are required to commit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../ui/presenters/git_repository/author_configuration_handler.py" line="88"/>
         <source>Git identity could not be saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../ui/presenters/git_repository/author_configuration_handler.py" line="90"/>
+        <location filename="../../ui/presenters/git_repository/author_configuration_handler.py" line="98"/>
         <source>Could not save git identity for all projects. Uncheck the global option to save it only for this project.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../ui/views/diff_panel/dialogs.py" line="64"/>
+        <location filename="../../ui/presenters/git_repository/author_configuration_handler.py" line="103"/>
+        <source>Could not save git identity for all repositories. Uncheck the global option to save it only for this repository.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../ui/views/diff_panel/dialogs.py" line="71"/>
         <source>Configure Author</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../ui/views/diff_panel/dialogs.py" line="68"/>
+        <location filename="../../ui/views/diff_panel/dialogs.py" line="80"/>
         <source>Enter the name and email you&apos;d like to use for your git identity, which is used for authoring project iterations.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../ui/views/diff_panel/dialogs.py" line="87"/>
-        <source>Configure globally for all projects</source>
+        <location filename="../../ui/views/diff_panel/dialogs.py" line="85"/>
+        <source>Enter the name and email you&apos;d like to use for your git identity, which is used for authoring repository commits.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../ui/views/diff_panel/dialogs.py" line="102"/>
-        <source>Name:</source>
+        <source>Configure globally for all projects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../ui/views/diff_panel/dialogs.py" line="103"/>
+        <source>Configure globally for all repositories</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../ui/views/diff_panel/dialogs.py" line="119"/>
+        <source>Name:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../ui/views/diff_panel/dialogs.py" line="120"/>
         <source>Email:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../ui/views/diff_panel/dialogs.py" line="110"/>
+        <location filename="../../ui/views/diff_panel/dialogs.py" line="130"/>
         <source>Global configuration option disabled because global config file not writable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../ui/views/diff_panel/dialogs.py" line="142"/>
+        <location filename="../../ui/views/diff_panel/dialogs.py" line="168"/>
         <source>This operation will overwrite the current file(s) on disk with the selected saved copies.
 
 All open FreeCAD documents will be closed and reopened to ensure links are updated.
@@ -75,49 +118,64 @@ Saved history will not be affected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../ui/views/diff_panel/dialogs.py" line="170"/>
+        <location filename="../../ui/views/diff_panel/dialogs.py" line="187"/>
         <location filename="../../ui/views/document_diff/summary_bar.py" line="66"/>
         <source>Restore All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../ui/views/diff_panel/dialogs.py" line="174"/>
+        <location filename="../../ui/views/diff_panel/dialogs.py" line="191"/>
         <source>Which files would you like to restore?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../ui/views/diff_panel/dialogs.py" line="179"/>
+        <location filename="../../ui/views/diff_panel/dialogs.py" line="201"/>
         <source>Restore only the FreeCAD files changed in the selected iteration. Other files on disk are left unchanged.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../ui/views/diff_panel/dialogs.py" line="187"/>
+        <location filename="../../ui/views/diff_panel/dialogs.py" line="206"/>
+        <source>Restore only the FreeCAD files changed in the selected commit. Other files on disk are left unchanged.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../ui/views/diff_panel/dialogs.py" line="218"/>
         <source>Restore all saved FreeCAD files to their state in this history entry. Saved FreeCAD files that did not exist in this entry will be removed. Files that have not been saved to history will be kept.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../ui/views/diff_panel/dialogs.py" line="177"/>
+        <location filename="../../ui/views/diff_panel/dialogs.py" line="359"/>
+        <source>Edit .gitignore</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../ui/views/diff_panel/dialogs.py" line="194"/>
         <source>Listed FreeCAD files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../ui/views/diff_panel/dialogs.py" line="185"/>
+        <location filename="../../ui/views/diff_panel/dialogs.py" line="38"/>
+        <source>Enter commit notes (subject and optional body)...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../ui/views/diff_panel/dialogs.py" line="210"/>
         <source>All FreeCAD files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../ui/views/diff_panel/dialogs.py" line="40"/>
-        <location filename="../../ui/views/diff_panel/dialogs.py" line="120"/>
+        <location filename="../../ui/views/diff_panel/dialogs.py" line="47"/>
+        <location filename="../../ui/views/diff_panel/dialogs.py" line="137"/>
         <source>OK</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../ui/views/diff_panel/dialogs.py" line="41"/>
-        <location filename="../../ui/views/diff_panel/dialogs.py" line="121"/>
-        <location filename="../../ui/views/diff_panel/dialogs.py" line="155"/>
-        <location filename="../../ui/views/diff_panel/dialogs.py" line="221"/>
-        <location filename="../../ui/views/diff_panel/dialogs.py" line="293"/>
-        <location filename="../../ui/views/diff_panel/dialogs.py" line="339"/>
+        <location filename="../../ui/views/diff_panel/dialogs.py" line="48"/>
+        <location filename="../../ui/views/diff_panel/dialogs.py" line="138"/>
+        <location filename="../../ui/views/diff_panel/dialogs.py" line="173"/>
+        <location filename="../../ui/views/diff_panel/dialogs.py" line="246"/>
+        <location filename="../../ui/views/diff_panel/dialogs.py" line="333"/>
+        <location filename="../../ui/views/diff_panel/dialogs.py" line="379"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
@@ -127,38 +185,64 @@ Saved history will not be affected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../ui/presenters/git_repository/commit_iteration_handler.py" line="60"/>
+        <location filename="../../ui/presenters/git_repository/commit_iteration_handler.py" line="59"/>
+        <source>No Staged Files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../ui/presenters/git_repository/commit_iteration_handler.py" line="61"/>
         <source>There are no reviewed files to save.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../ui/presenters/git_repository/commit_iteration_handler.py" line="89"/>
+        <location filename="../../ui/presenters/git_repository/commit_iteration_handler.py" line="62"/>
+        <source>There are no staged files to commit.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../ui/presenters/git_repository/commit_iteration_handler.py" line="84"/>
+        <source>Commit notes cannot be empty</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../ui/presenters/git_repository/commit_iteration_handler.py" line="95"/>
         <source>Git commit failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../ui/presenters/git_repository/commit_iteration_handler.py" line="78"/>
+        <location filename="../../ui/presenters/git_repository/commit_iteration_handler.py" line="81"/>
         <source>Empty Notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../ui/presenters/git_repository/commit_iteration_handler.py" line="79"/>
+        <location filename="../../ui/presenters/git_repository/commit_iteration_handler.py" line="83"/>
         <source>Iteration notes cannot be empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../ui/views/diff_panel/dialogs.py" line="25"/>
-        <location filename="../../ui/views/history/repository_header.py" line="93"/>
+        <location filename="../../ui/views/history/repository_header.py" line="100"/>
         <source>Save Iteration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../ui/views/diff_panel/dialogs.py" line="29"/>
+        <location filename="../../ui/views/diff_panel/dialogs.py" line="25"/>
+        <location filename="../../ui/views/history/repository_header.py" line="100"/>
+        <source>Commit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../ui/views/diff_panel/dialogs.py" line="30"/>
         <source>Enter iteration notes:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../ui/views/diff_panel/dialogs.py" line="33"/>
+        <location filename="../../ui/views/diff_panel/dialogs.py" line="30"/>
+        <source>Enter commit notes:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../ui/views/diff_panel/dialogs.py" line="37"/>
         <source>Enter iteration notes (subject and optional body)...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -168,62 +252,97 @@ Saved history will not be affected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../ui/presenters/git_repository/initialize_repository_handler.py" line="40"/>
+        <location filename="../../ui/presenters/git_repository/initialize_repository_handler.py" line="46"/>
         <source>No open documents are available for project initialization. Please open at least one saved document in the root location you&apos;d like to initialize a new project.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../ui/presenters/git_repository/initialize_repository_handler.py" line="56"/>
+        <location filename="../../ui/presenters/git_repository/initialize_repository_handler.py" line="52"/>
+        <source>No open documents are available for repository initialization. Please open at least one saved document in the root location you&apos;d like to initialize a new repository.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../ui/presenters/git_repository/initialize_repository_handler.py" line="64"/>
         <source>Initialization Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../ui/presenters/git_repository/initialize_repository_handler.py" line="77"/>
+        <source>Repository Initialized</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../ui/presenters/git_repository/gitignore_handler.py" line="36"/>
         <location filename="../../ui/presenters/git_repository/gitignore_handler.py" line="48"/>
-        <location filename="../../ui/presenters/git_repository/initialize_repository_handler.py" line="57"/>
+        <location filename="../../ui/presenters/git_repository/initialize_repository_handler.py" line="65"/>
         <source>Unknown error occurred</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../ui/presenters/git_repository/initialize_repository_handler.py" line="64"/>
+        <location filename="../../ui/presenters/git_repository/initialize_repository_handler.py" line="73"/>
         <source>Initialized project: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../ui/presenters/git_repository/initialize_repository_handler.py" line="67"/>
+        <location filename="../../ui/presenters/git_repository/initialize_repository_handler.py" line="74"/>
+        <source>Initialized repository: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../ui/presenters/git_repository/initialize_repository_handler.py" line="77"/>
         <source>Project Initialized</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../ui/views/diff_panel/dialogs.py" line="248"/>
+        <location filename="../../ui/views/diff_panel/dialogs.py" line="274"/>
         <source>Initialize Project</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../ui/views/diff_panel/dialogs.py" line="253"/>
+        <location filename="../../ui/views/diff_panel/dialogs.py" line="274"/>
+        <source>Initialize Repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../ui/views/diff_panel/dialogs.py" line="285"/>
         <source>Choose a directory to initialize based on currently open documents. The selected directory will be the root of your project:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../ui/views/diff_panel/dialogs.py" line="275"/>
+        <location filename="../../ui/views/diff_panel/dialogs.py" line="290"/>
+        <source>Choose a directory to initialize based on currently open documents. The selected directory will be the root of your repository:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../ui/views/diff_panel/dialogs.py" line="310"/>
         <source>Already inside project</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../ui/views/diff_panel/dialogs.py" line="287"/>
+        <location filename="../../ui/views/diff_panel/dialogs.py" line="311"/>
+        <source>Already inside repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../ui/views/diff_panel/dialogs.py" line="325"/>
         <source>All listed directories are already inside projects.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../ui/views/diff_panel/dialogs.py" line="291"/>
+        <location filename="../../ui/views/diff_panel/dialogs.py" line="326"/>
+        <source>All listed directories are already inside repositories.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../ui/views/diff_panel/dialogs.py" line="331"/>
         <source>Initialize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../entrypoints/commands.py" line="206"/>
-        <location filename="../../ui/presenters/workbench_command_presenter.py" line="135"/>
-        <location filename="../../ui/presenters/workbench_command_presenter.py" line="151"/>
-        <location filename="../../ui/presenters/workbench_command_presenter.py" line="171"/>
+        <location filename="../../entrypoints/commands.py" line="250"/>
+        <location filename="../../ui/presenters/workbench_command_presenter.py" line="136"/>
+        <location filename="../../ui/presenters/workbench_command_presenter.py" line="155"/>
+        <location filename="../../ui/presenters/workbench_command_presenter.py" line="178"/>
         <source>No project detected. Open a FreeCAD document in a project first.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -233,7 +352,7 @@ Saved history will not be affected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../ui/views/diff_panel/dialogs.py" line="319"/>
+        <location filename="../../ui/views/diff_panel/dialogs.py" line="359"/>
         <source>Edit Ignored Files</source>
         <translation type="unfinished"></translation>
     </message>
@@ -243,12 +362,12 @@ Saved history will not be affected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../ui/views/diff_panel/dialogs.py" line="338"/>
+        <location filename="../../ui/views/diff_panel/dialogs.py" line="378"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../ui/views/diff_panel/dialogs.py" line="324"/>
+        <location filename="../../ui/views/diff_panel/dialogs.py" line="369"/>
         <source>Update the ignored files list. Lines starting with a &quot;#&quot; are considered comments. Click &lt;a href=&quot;%1&quot;&gt;here&lt;/a&gt; to learn about the full syntax.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -263,82 +382,137 @@ Saved history will not be affected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../ui/presenters/presentation_models.py" line="45"/>
+        <location filename="../../ui/presenters/presentation_models.py" line="50"/>
         <source>Cannot find previous snapshot. Tree comparison cannot be generated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../ui/presenters/presentation_models.py" line="62"/>
+        <location filename="../../ui/presenters/presentation_models.py" line="54"/>
+        <source>Cannot find previous snapshot. Tree diff cannot be generated.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../ui/presenters/presentation_models.py" line="72"/>
         <source>No snapshot available for this document. Tree comparison cannot be generated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../ui/presenters/presentation_models.py" line="78"/>
+        <location filename="../../ui/presenters/presentation_models.py" line="75"/>
+        <source>No snapshot available for this document. Tree diff cannot be generated.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../ui/presenters/presentation_models.py" line="91"/>
         <source>Click to open the document and generate a comparison.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../ui/presenters/presentation_models.py" line="92"/>
+        <source>Click to open the document and generate a diff.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../ui/presenters/presentation_models.py" line="110"/>
         <source>The old snapshot is invalid, so a tree comparison cannot be generated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../ui/presenters/presentation_models.py" line="108"/>
+        <location filename="../../ui/presenters/presentation_models.py" line="113"/>
+        <source>The old snapshot is invalid, so a tree diff cannot be generated.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../ui/presenters/presentation_models.py" line="131"/>
         <source>The selected snapshot is invalid, so a tree comparison cannot be generated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../ui/presenters/presentation_models.py" line="135"/>
+        <location filename="../../ui/presenters/presentation_models.py" line="134"/>
+        <source>The selected snapshot is invalid, so a tree diff cannot be generated.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../ui/presenters/presentation_models.py" line="160"/>
         <source>File changed on disk but no parametric changes detected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../ui/presenters/presentation_models.py" line="122"/>
+        <location filename="../../ui/presenters/presentation_models.py" line="147"/>
         <source>Diff computation failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../ui/views/history/history_list.py" line="141"/>
+        <location filename="../../ui/views/history/history_list.py" line="142"/>
         <source>Mark All Files Reviewed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../ui/views/history/history_list.py" line="149"/>
-        <source>Remove document(s) from Reviewed. The current file(s) stay unchanged and will not be saved in the next iteration until reviewed again.</source>
+        <location filename="../../ui/views/history/history_list.py" line="142"/>
+        <source>Mark All Files Staged</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../ui/views/history/history_list.py" line="156"/>
+        <source>Remove document(s) from Reviewed. The current file(s) stay unchanged and will not be saved in the next iteration until reviewed again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../ui/views/history/history_list.py" line="161"/>
+        <source>Remove document(s) from Staged. The current file(s) stay unchanged and will not be saved in the next commit until staged again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../ui/views/history/history_list.py" line="167"/>
         <source>Remove All Files From Reviewed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../ui/views/history/history_list.py" line="157"/>
-        <source>Restore All Reviewed Files</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../ui/views/history/history_list.py" line="171"/>
-        <source>Restore All Files From Iteration</source>
+        <location filename="../../ui/views/history/history_list.py" line="168"/>
+        <source>Remove All Files From Staged</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../ui/views/history/history_list.py" line="172"/>
+        <source>Restore All Reviewed Files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../ui/views/history/history_list.py" line="172"/>
+        <source>Restore All Staged Files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../ui/views/history/history_list.py" line="189"/>
+        <source>Restore All Files From Iteration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../ui/views/history/history_list.py" line="190"/>
+        <source>Restore All Files From Commit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../ui/views/history/history_list.py" line="195"/>
         <source>Copy Iteration ID to Clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../ui/views/document_diff/summary_bar.py" line="39"/>
+        <location filename="../../ui/views/history/history_list.py" line="196"/>
+        <source>Copy Commit ID to Clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../ui/views/document_diff/summary_bar.py" line="40"/>
         <source>Modified file count</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../ui/views/document_diff/summary_bar.py" line="42"/>
+        <location filename="../../ui/views/document_diff/summary_bar.py" line="43"/>
         <source>Added file count</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../ui/views/document_diff/summary_bar.py" line="45"/>
+        <location filename="../../ui/views/document_diff/summary_bar.py" line="46"/>
         <source>Deleted file count</source>
         <translation type="unfinished"></translation>
     </message>
@@ -348,19 +522,31 @@ Saved history will not be affected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../ui/views/document_diff/summary_bar.py" line="67"/>
+        <location filename="../../ui/views/document_diff/summary_bar.py" line="56"/>
+        <source>+ Mark All Staged</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../ui/views/document_diff/summary_bar.py" line="73"/>
         <source>Choose which files to restore from the selected iteration.
 Current files on disk can be overwritten or removed.
 Saved history will not be affected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../ui/views/document_diff/summary_bar.py" line="82"/>
+        <location filename="../../ui/views/document_diff/summary_bar.py" line="79"/>
+        <source>Choose which files to restore from the selected commit.
+Current files on disk can be overwritten or removed.
+Saved history will not be affected.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../ui/views/document_diff/summary_bar.py" line="90"/>
         <source>Remove All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../ui/views/document_diff/document_row.py" line="19"/>
+        <location filename="../../ui/views/document_diff/document_row.py" line="25"/>
         <source>Remove document(s) from Reviewed.
 The current file(s) stay unchanged.
 They will not be saved in the next iteration until reviewed again.</source>
@@ -378,25 +564,45 @@ They will not be saved in the next iteration until reviewed again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../ui/views/document_diff/tree.py" line="48"/>
+        <location filename="../../ui/views/document_diff/tree.py" line="49"/>
         <location filename="../../ui/views/document_diff/tree_items.py" line="24"/>
         <source>Unnamed Document</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../ui/views/document_diff/document_row.py" line="101"/>
+        <location filename="../../ui/views/document_diff/document_row.py" line="31"/>
+        <source>Remove document(s) from Staged.
+The current file(s) stay unchanged.
+They will not be saved in the next commit until staged again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../ui/views/document_diff/document_row.py" line="109"/>
         <source>+ Reviewed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../ui/views/document_diff/document_row.py" line="111"/>
+        <location filename="../../ui/views/document_diff/document_row.py" line="109"/>
+        <source>+ Staged</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../ui/views/document_diff/document_row.py" line="119"/>
         <source>Remove</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../ui/views/document_diff/document_row.py" line="120"/>
+        <location filename="../../ui/views/document_diff/document_row.py" line="135"/>
         <source>Restore the selected file.
 This overwrites %1 on disk with a copy of the file as it was saved in the selected iteration.
+THE CURRENT FILE WILL BE OVERWRITTEN BY THIS OPERATION.
+Saved history will not be affected.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../ui/views/document_diff/document_row.py" line="142"/>
+        <source>Restore the selected file.
+This overwrites %1 on disk with a copy of the file as it was saved in the selected commit.
 THE CURRENT FILE WILL BE OVERWRITTEN BY THIS OPERATION.
 Saved history will not be affected.</source>
         <translation type="unfinished"></translation>
@@ -412,43 +618,83 @@ Saved history will not be affected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../ui/views/history/panel.py" line="91"/>
+        <location filename="../../ui/views/document_diff/node_row.py" line="57"/>
+        <source>Open 3D diff</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../ui/views/history/panel.py" line="96"/>
         <source>Iterations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../ui/views/history/repository_header.py" line="83"/>
+        <location filename="../../ui/views/history/repository_header.py" line="88"/>
         <source>Refresh Project and Iterations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../ui/views/history/panel.py" line="138"/>
+        <location filename="../../ui/views/history/panel.py" line="65"/>
+        <source>No commits to display.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../ui/views/history/panel.py" line="96"/>
+        <source>Commits</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../ui/views/history/panel.py" line="144"/>
         <source>Current Files Area</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../ui/views/history/panel.py" line="144"/>
+        <source>Working Tree</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../ui/views/history/panel.py" line="150"/>
         <source>Reviewed Area</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../ui/views/history/panel.py" line="62"/>
+        <location filename="../../ui/views/history/panel.py" line="150"/>
+        <source>Staging Area</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../ui/views/history/panel.py" line="64"/>
         <source>No iterations to display.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../ui/views/history/formatters.py" line="27"/>
+        <location filename="../../ui/views/history/formatters.py" line="28"/>
         <source>Yesterday</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../ui/views/history/repository_header.py" line="63"/>
+        <location filename="../../ui/views/history/repository_header.py" line="64"/>
         <source>No project detected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../ui/views/history/repository_header.py" line="70"/>
+        <location filename="../../ui/views/history/repository_header.py" line="64"/>
+        <source>No repository detected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../ui/views/history/repository_header.py" line="72"/>
         <source>Project: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../ui/views/history/repository_header.py" line="72"/>
+        <source>Repository: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../ui/views/history/repository_header.py" line="89"/>
+        <source>Refresh Repository and Commits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -467,7 +713,7 @@ Saved history will not be affected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../ui/views/property_diff/tree_items.py" line="27"/>
+        <location filename="../../ui/views/property_diff/tree_items.py" line="28"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
@@ -477,7 +723,7 @@ Saved history will not be affected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../ui/views/settings_preferences_page.py" line="69"/>
+        <location filename="../../ui/views/settings_preferences_page.py" line="72"/>
         <source>Settings apply only during tree comparisons. Saved tree snapshots are unaffected by these settings.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -522,27 +768,42 @@ Saved history will not be affected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../ui/views/settings_preferences_page.py" line="257"/>
+        <location filename="../../ui/views/settings_preferences_page.py" line="121"/>
+        <source>Use git terminology (Commit, Repository, Staged, …)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../ui/views/settings_preferences_page.py" line="130"/>
+        <source>Relabel the interface with the underlying git terms instead of the CAD-friendly defaults. Takes full effect after restarting FreeCAD.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../ui/views/settings_preferences_page.py" line="133"/>
+        <source>Terminology</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../ui/views/settings_preferences_page.py" line="278"/>
         <source>Use default exclusion list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../ui/views/settings_preferences_page.py" line="258"/>
+        <location filename="../../ui/views/settings_preferences_page.py" line="279"/>
         <source>Use custom exclusion list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../entrypoints/workbench.py" line="216"/>
+        <location filename="../../entrypoints/workbench.py" line="222"/>
         <source>History</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../ui/presenters/document_diff/restore_handler.py" line="104"/>
         <location filename="../../ui/presenters/document_diff/restore_handler.py" line="108"/>
-        <location filename="../../ui/views/diff_panel/dialogs.py" line="141"/>
-        <location filename="../../ui/views/diff_panel/dialogs.py" line="154"/>
-        <location filename="../../ui/views/diff_panel/dialogs.py" line="220"/>
-        <location filename="../../ui/views/document_diff/document_row.py" line="128"/>
+        <location filename="../../ui/views/diff_panel/dialogs.py" line="159"/>
+        <location filename="../../ui/views/diff_panel/dialogs.py" line="172"/>
+        <location filename="../../ui/views/diff_panel/dialogs.py" line="245"/>
+        <location filename="../../ui/views/document_diff/document_row.py" line="145"/>
         <source>Restore</source>
         <translation type="unfinished"></translation>
     </message>
@@ -555,12 +816,17 @@ Saved history will not be affected.</source>
 <context>
     <name>HistoryCloseDiffWindows</name>
     <message>
-        <location filename="../../entrypoints/commands.py" line="317"/>
+        <location filename="../../entrypoints/commands.py" line="373"/>
         <source>Close Comparison Windows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../entrypoints/commands.py" line="318"/>
+        <location filename="../../entrypoints/commands.py" line="374"/>
+        <source>Close Diff Windows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../entrypoints/commands.py" line="379"/>
         <source>Close every document starting with &apos;Diff_&apos; without saving</source>
         <translation type="unfinished"></translation>
     </message>
@@ -568,13 +834,23 @@ Saved history will not be affected.</source>
 <context>
     <name>HistoryCommit</name>
     <message>
-        <location filename="../../entrypoints/commands.py" line="95"/>
+        <location filename="../../entrypoints/commands.py" line="96"/>
         <source>Save Iteration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../entrypoints/commands.py" line="96"/>
+        <location filename="../../entrypoints/commands.py" line="97"/>
+        <source>Commit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../entrypoints/commands.py" line="100"/>
         <source>Save reviewed changes as an iteration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../entrypoints/commands.py" line="101"/>
+        <source>Commit the staged changes</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -594,38 +870,58 @@ Saved history will not be affected.</source>
 <context>
     <name>HistoryInitializeGitRepository</name>
     <message>
-        <location filename="../../entrypoints/commands.py" line="149"/>
+        <location filename="../../entrypoints/commands.py" line="169"/>
         <source>Initialize Project</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../entrypoints/commands.py" line="150"/>
+        <location filename="../../entrypoints/commands.py" line="170"/>
+        <source>Initialize Repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../entrypoints/commands.py" line="176"/>
         <source>Initialize a new project in the selected directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../entrypoints/commands.py" line="180"/>
+        <source>Initialize a new repository in the selected directory</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>HistoryOpenAllDocumentsInRepository</name>
     <message>
-        <location filename="../../entrypoints/commands.py" line="176"/>
+        <location filename="../../entrypoints/commands.py" line="208"/>
         <source>Open All Documents in Project</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../entrypoints/commands.py" line="180"/>
+        <location filename="../../entrypoints/commands.py" line="212"/>
+        <source>Open All Documents in Repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../entrypoints/commands.py" line="218"/>
         <source>Open every .FCStd file found in the project. Useful for generating en masse.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../entrypoints/commands.py" line="222"/>
+        <source>Open every .FCStd file found in the repository. Useful for generating en masse.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>HistoryOpenDiffWindow</name>
     <message>
-        <location filename="../../entrypoints/commands.py" line="292"/>
+        <location filename="../../entrypoints/commands.py" line="347"/>
         <source>Open History Panel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../entrypoints/commands.py" line="293"/>
+        <location filename="../../entrypoints/commands.py" line="348"/>
         <source>Open history panel view</source>
         <translation type="unfinished"></translation>
     </message>
@@ -633,12 +929,12 @@ Saved history will not be affected.</source>
 <context>
     <name>HistoryRecomputeActiveDocument</name>
     <message>
-        <location filename="../../entrypoints/commands.py" line="267"/>
+        <location filename="../../entrypoints/commands.py" line="322"/>
         <source>Recompute Active Document</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../entrypoints/commands.py" line="268"/>
+        <location filename="../../entrypoints/commands.py" line="323"/>
         <source>Recompute the active document</source>
         <translation type="unfinished"></translation>
     </message>
@@ -646,12 +942,12 @@ Saved history will not be affected.</source>
 <context>
     <name>HistoryRecomputeAllOpenDocuments</name>
     <message>
-        <location filename="../../entrypoints/commands.py" line="244"/>
+        <location filename="../../entrypoints/commands.py" line="299"/>
         <source>Recompute All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../entrypoints/commands.py" line="245"/>
+        <location filename="../../entrypoints/commands.py" line="300"/>
         <source>Recompute every open document</source>
         <translation type="unfinished"></translation>
     </message>
@@ -659,28 +955,50 @@ Saved history will not be affected.</source>
 <context>
     <name>HistoryRefreshRepository</name>
     <message>
-        <location filename="../../entrypoints/commands.py" line="120"/>
+        <location filename="../../entrypoints/commands.py" line="127"/>
         <source>Refresh Project</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../entrypoints/commands.py" line="121"/>
+        <location filename="../../entrypoints/commands.py" line="128"/>
+        <source>Refresh Repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../entrypoints/commands.py" line="138"/>
         <source>Refresh the detected project and reload iterations.
 Open at least one FreeCAD document located within a project before running this command.
 How it works: open FreeCAD documents are checked one by one until one is found to be located within a project.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../entrypoints/commands.py" line="146"/>
+        <source>Refresh the detected repository and reload commits.
+Open at least one FreeCAD document located within a repository before running this command.
+How it works: open FreeCAD documents are checked one by one until one is found to be located within a repository.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>HistoryUpdateGitIgnore</name>
     <message>
-        <location filename="../../entrypoints/commands.py" line="219"/>
+        <location filename="../../entrypoints/commands.py" line="266"/>
         <source>Edit Ignored Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../entrypoints/commands.py" line="220"/>
+        <location filename="../../entrypoints/commands.py" line="267"/>
+        <source>Edit .gitignore</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../entrypoints/commands.py" line="273"/>
         <source>Edit project ignored files list (.gitignore)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../entrypoints/commands.py" line="277"/>
+        <source>Edit repository ignored files list (.gitignore)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -688,15 +1006,20 @@ How it works: open FreeCAD documents are checked one by one until one is found t
     <name>Workbench</name>
     <message>
         <location filename="../../entrypoints/workbench.py" line="59"/>
-        <location filename="../../entrypoints/workbench.py" line="77"/>
-        <location filename="../../entrypoints/workbench.py" line="81"/>
-        <location filename="../../entrypoints/workbench.py" line="102"/>
+        <location filename="../../entrypoints/workbench.py" line="83"/>
+        <location filename="../../entrypoints/workbench.py" line="87"/>
+        <location filename="../../entrypoints/workbench.py" line="108"/>
         <source>History</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../entrypoints/workbench.py" line="60"/>
+        <location filename="../../entrypoints/workbench.py" line="63"/>
         <source>Track project iterations and history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../entrypoints/workbench.py" line="64"/>
+        <source>Track repository commits and history</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/freecad/history_wb/ui/presenters/git_repository/author_configuration_handler.py
+++ b/freecad/history_wb/ui/presenters/git_repository/author_configuration_handler.py
@@ -14,7 +14,7 @@ from ....application.actions.git_config.can_write_global_git_identity import (
 from ....application.actions.git_config.get_git_identity import GetGitIdentityAction
 from ....application.actions.git_config.save_git_identity import SaveGitIdentityAction
 from ....domain.git.models import GitIdentity, GitRepository
-from ....utils import translate
+from ....utils import term, translate
 from ...views.diff_panel.dialogs import GitConfigDialogResult
 
 
@@ -65,8 +65,11 @@ class AuthorConfigurationHandler:
 
             if not dialog_result.author_name or not dialog_result.author_email:
                 self._show_warning_message(
-                    translate("History", "Save Iteration Failed"),
-                    translate("History", "Name and email are required to save iteration"),
+                    term(translate("History", "Save Iteration Failed"), translate("History", "Commit Failed")),
+                    term(
+                        translate("History", "Name and email are required to save iteration"),
+                        translate("History", "Name and email are required to commit"),
+                    ),
                 )
                 return False
 
@@ -81,16 +84,23 @@ class AuthorConfigurationHandler:
             # Local save failed; give up
             if not dialog_result.should_save_globally:
                 self._show_error_message(
-                    translate("History", "Save Iteration Failed"),
+                    term(translate("History", "Save Iteration Failed"), translate("History", "Commit Failed")),
                     translate("History", "Git identity could not be saved"),
                 )
                 return False
 
             # Global save failed; retry with local-only option
-            retry_message = translate(
-                "History",
-                "Could not save git identity for all projects. "
-                "Uncheck the global option to save it only for this project.",
+            retry_message = term(
+                translate(
+                    "History",
+                    "Could not save git identity for all projects. "
+                    "Uncheck the global option to save it only for this project.",
+                ),
+                translate(
+                    "History",
+                    "Could not save git identity for all repositories. "
+                    "Uncheck the global option to save it only for this repository.",
+                ),
             )
             initial_values = dialog_result
 

--- a/freecad/history_wb/ui/presenters/git_repository/commit_iteration_handler.py
+++ b/freecad/history_wb/ui/presenters/git_repository/commit_iteration_handler.py
@@ -13,7 +13,7 @@ from ....application.actions.git_config.get_git_identity import GetGitIdentityAc
 from ....application.actions.git_history.get_staged_file_paths import GetStagedFilePathsAction
 from ....application.actions.git_workflow.commit_staging import CommitStagingAction
 from ....domain.git.models import GitRepository
-from ....utils import translate
+from ....utils import term, translate
 from .author_configuration_handler import AuthorConfigurationHandler
 
 
@@ -56,8 +56,11 @@ class CommitIterationHandler:
         staged_result = self._get_staged_file_paths_action.execute(repo)
         if not staged_result.is_success or not staged_result.data:
             self._show_info_message(
-                translate("History", "No Reviewed Files"),
-                translate("History", "There are no reviewed files to save."),
+                term(translate("History", "No Reviewed Files"), translate("History", "No Staged Files")),
+                term(
+                    translate("History", "There are no reviewed files to save."),
+                    translate("History", "There are no staged files to commit."),
+                ),
             )
             return False
 
@@ -76,7 +79,10 @@ class CommitIterationHandler:
         if not trimmed_message:
             self._show_warning_message(
                 translate("History", "Empty Notes"),
-                translate("History", "Iteration notes cannot be empty"),
+                term(
+                    translate("History", "Iteration notes cannot be empty"),
+                    translate("History", "Commit notes cannot be empty"),
+                ),
             )
             return False
 
@@ -85,7 +91,7 @@ class CommitIterationHandler:
             return True
 
         self._show_error_message(
-            translate("History", "Save Iteration Failed"),
+            term(translate("History", "Save Iteration Failed"), translate("History", "Commit Failed")),
             result.message or translate("History", "Git commit failed"),
         )
         return False

--- a/freecad/history_wb/ui/presenters/git_repository/initialize_repository_handler.py
+++ b/freecad/history_wb/ui/presenters/git_repository/initialize_repository_handler.py
@@ -7,7 +7,7 @@ from ....application.actions.git_repo.get_git_repository_init_candidates import 
     GetGitRepositoryInitCandidatesAction,
 )
 from ....application.actions.git_repo.initialize_git_repository import InitializeGitRepositoryAction
-from ....utils import Log, translate
+from ....utils import Log, term, translate
 from ...state import ApplicationState
 
 
@@ -37,11 +37,19 @@ class InitializeRepositoryHandler:
         if not candidates_result.is_success:
             self._show_info_message(
                 translate("History", "No Directories Available"),
-                translate(
-                    "History",
-                    "No open documents are available for project initialization. "
-                    "Please open at least one saved document in the root location "
-                    "you'd like to initialize a new project.",
+                term(
+                    translate(
+                        "History",
+                        "No open documents are available for project initialization. "
+                        "Please open at least one saved document in the root location "
+                        "you'd like to initialize a new project.",
+                    ),
+                    translate(
+                        "History",
+                        "No open documents are available for repository initialization. "
+                        "Please open at least one saved document in the root location "
+                        "you'd like to initialize a new repository.",
+                    ),
                 ),
             )
             return False
@@ -61,10 +69,12 @@ class InitializeRepositoryHandler:
         repository = init_result.data
         self._application_state.git_repository = repository
 
-        success_template = translate("History", "Initialized project: %1")
+        success_template = term(
+            translate("History", "Initialized project: %1"), translate("History", "Initialized repository: %1")
+        )
         success_message = success_template.replace("%1", repository.absolute_path)
         self._show_info_message(
-            translate("History", "Project Initialized"),
+            term(translate("History", "Project Initialized"), translate("History", "Repository Initialized")),
             success_message,
         )
         Log.info(f"Initialized git repository at {repository.absolute_path}")

--- a/freecad/history_wb/ui/presenters/presentation_models.py
+++ b/freecad/history_wb/ui/presenters/presentation_models.py
@@ -8,6 +8,7 @@ from typing import Any, cast
 from ...domain.diff.models import DiffState
 from ...qt import QtCore, QtGui
 from ...resources import get_icon_path
+from ...utils import term
 
 
 __all__ = [
@@ -42,9 +43,15 @@ class OldSnapshotMissingIndicator(DocumentStatusIndicator):
         super().__init__(
             tooltip=cast(
                 str,
-                QtCore.QT_TRANSLATE_NOOP(
-                    "History",
-                    "Cannot find previous snapshot. Tree comparison cannot be generated.",
+                term(
+                    QtCore.QT_TRANSLATE_NOOP(
+                        "History",
+                        "Cannot find previous snapshot. Tree comparison cannot be generated.",
+                    ),
+                    QtCore.QT_TRANSLATE_NOOP(
+                        "History",
+                        "Cannot find previous snapshot. Tree diff cannot be generated.",
+                    ),
                 ),
             ),
             icon=QtGui.QIcon(str(get_icon_path("DocumentStatusOldSnapshotMissing.svg"))),
@@ -59,8 +66,13 @@ class NewSnapshotMissingIndicator(DocumentStatusIndicator):
         super().__init__(
             tooltip=cast(
                 str,
-                QtCore.QT_TRANSLATE_NOOP(
-                    "History", "No snapshot available for this document. Tree comparison cannot be generated."
+                term(
+                    QtCore.QT_TRANSLATE_NOOP(
+                        "History", "No snapshot available for this document. Tree comparison cannot be generated."
+                    ),
+                    QtCore.QT_TRANSLATE_NOOP(
+                        "History", "No snapshot available for this document. Tree diff cannot be generated."
+                    ),
                 ),
             ),
             icon=QtGui.QIcon(str(get_icon_path("DocumentStatusSnapshotMissing.svg"))),
@@ -75,7 +87,10 @@ class WorkingTreeDocumentClosedIndicator(DocumentStatusIndicator):
         super().__init__(
             tooltip=cast(
                 str,
-                QtCore.QT_TRANSLATE_NOOP("History", "Click to open the document and generate a comparison."),
+                term(
+                    QtCore.QT_TRANSLATE_NOOP("History", "Click to open the document and generate a comparison."),
+                    QtCore.QT_TRANSLATE_NOOP("History", "Click to open the document and generate a diff."),
+                ),
             ),
             icon=QtGui.QIcon(str(get_icon_path("OpenDocument.svg"))),
         )
@@ -89,8 +104,13 @@ class OldInvalidSnapshotIndicator(DocumentStatusIndicator):
         super().__init__(
             tooltip=cast(
                 str,
-                QtCore.QT_TRANSLATE_NOOP(
-                    "History", "The old snapshot is invalid, so a tree comparison cannot be generated."
+                term(
+                    QtCore.QT_TRANSLATE_NOOP(
+                        "History", "The old snapshot is invalid, so a tree comparison cannot be generated."
+                    ),
+                    QtCore.QT_TRANSLATE_NOOP(
+                        "History", "The old snapshot is invalid, so a tree diff cannot be generated."
+                    ),
                 ),
             ),
             icon=QtGui.QIcon(str(get_icon_path("DocumentStatusInvalidSnapshot.svg"))),
@@ -105,8 +125,13 @@ class NewInvalidSnapshotIndicator(DocumentStatusIndicator):
         super().__init__(
             tooltip=cast(
                 str,
-                QtCore.QT_TRANSLATE_NOOP(
-                    "History", "The selected snapshot is invalid, so a tree comparison cannot be generated."
+                term(
+                    QtCore.QT_TRANSLATE_NOOP(
+                        "History", "The selected snapshot is invalid, so a tree comparison cannot be generated."
+                    ),
+                    QtCore.QT_TRANSLATE_NOOP(
+                        "History", "The selected snapshot is invalid, so a tree diff cannot be generated."
+                    ),
                 ),
             ),
             icon=QtGui.QIcon(str(get_icon_path("DocumentStatusInvalidSnapshot.svg"))),

--- a/freecad/history_wb/ui/presenters/workbench_command_presenter.py
+++ b/freecad/history_wb/ui/presenters/workbench_command_presenter.py
@@ -28,7 +28,7 @@ from ...application.actions.git_repo.initialize_git_repository import Initialize
 from ...application.actions.git_workflow.commit_staging import CommitStagingAction
 from ...domain.git.models import GitRepository
 from ...qt import QtCore
-from ...utils import Log, translate
+from ...utils import Log, term, translate
 from ..state import ApplicationState
 from ..views.diff_panel.dialog_view import DialogView
 from ..views.diff_panel.dialogs import GitConfigDialogResult
@@ -131,8 +131,11 @@ class WorkbenchCommandPresenter(QtCore.QObject):
         repo = self._application_state.git_repository
         if repo is None:
             self._show_warning_message(
-                translate("History", "No Project"),
-                translate("History", "No project detected. Open a FreeCAD document in a project first."),
+                term(translate("History", "No Project"), translate("History", "No Repository")),
+                term(
+                    translate("History", "No project detected. Open a FreeCAD document in a project first."),
+                    translate("History", "No repository detected. Open a FreeCAD document in a repository first."),
+                ),
             )
             return False
 
@@ -147,8 +150,11 @@ class WorkbenchCommandPresenter(QtCore.QObject):
         repo = self._application_state.git_repository
         if repo is None:
             self._show_warning_message(
-                translate("History", "No Project"),
-                translate("History", "No project detected. Open a FreeCAD document in a project first."),
+                term(translate("History", "No Project"), translate("History", "No Repository")),
+                term(
+                    translate("History", "No project detected. Open a FreeCAD document in a project first."),
+                    translate("History", "No repository detected. Open a FreeCAD document in a repository first."),
+                ),
             )
             return False
 
@@ -167,8 +173,11 @@ class WorkbenchCommandPresenter(QtCore.QObject):
         repo = self._application_state.git_repository
         if repo is None:
             self._show_warning_message(
-                translate("History", "No Project"),
-                translate("History", "No project detected. Open a FreeCAD document in a project first."),
+                term(translate("History", "No Project"), translate("History", "No Repository")),
+                term(
+                    translate("History", "No project detected. Open a FreeCAD document in a project first."),
+                    translate("History", "No repository detected. Open a FreeCAD document in a repository first."),
+                ),
             )
             return
 

--- a/freecad/history_wb/ui/registry.py
+++ b/freecad/history_wb/ui/registry.py
@@ -62,18 +62,14 @@ class UIRegistry:
             RuntimeError: If not initialized
         """
         if self._workbench_command_presenter is None:
-            raise RuntimeError(
-                "Workbench command presenter not initialized. Workbench must be activated first."
-            )
+            raise RuntimeError("Workbench command presenter not initialized. Workbench must be activated first.")
         return self._workbench_command_presenter
 
     def register_application_state(self, state: "ApplicationState") -> None:
         """Register application state."""
         self._application_state = state
 
-    def register_workbench_command_presenter(
-        self, presenter: "WorkbenchCommandPresenter"
-    ) -> None:
+    def register_workbench_command_presenter(self, presenter: "WorkbenchCommandPresenter") -> None:
         """Register workbench command presenter."""
         self._workbench_command_presenter = presenter
 

--- a/freecad/history_wb/ui/views/diff_panel/dialogs.py
+++ b/freecad/history_wb/ui/views/diff_panel/dialogs.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 from ....domain.git.models import GitRepositoryInitCandidate
 from ....qt import QtWidgets
-from ....utils import translate
+from ....utils import term, translate
 from ..widgets.buttons import make_dialog_button_box
 
 
@@ -22,15 +22,22 @@ class GitConfigDialogResult:
 def show_save_iteration_dialog(parent: QtWidgets.QWidget) -> str | None:
     """Show Save Iteration dialog and return notes when accepted."""
     dialog = QtWidgets.QDialog(parent)
-    dialog.setWindowTitle(translate("History", "Save Iteration"))
+    dialog.setWindowTitle(term(translate("History", "Save Iteration"), translate("History", "Commit")))
     dialog.setSizeGripEnabled(True)
 
     layout = QtWidgets.QVBoxLayout(dialog)
-    label = QtWidgets.QLabel(translate("History", "Enter iteration notes:"))
+    label = QtWidgets.QLabel(
+        term(translate("History", "Enter iteration notes:"), translate("History", "Enter commit notes:"))
+    )
     layout.addWidget(label)
 
     text_edit = QtWidgets.QPlainTextEdit(dialog)
-    text_edit.setPlaceholderText(translate("History", "Enter iteration notes (subject and optional body)..."))
+    text_edit.setPlaceholderText(
+        term(
+            translate("History", "Enter iteration notes (subject and optional body)..."),
+            translate("History", "Enter commit notes (subject and optional body)..."),
+        )
+    )
     text_edit.setTabStopDistance(40)
     text_edit.setMinimumHeight(100)
     text_edit.setSizePolicy(QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Expanding)
@@ -65,10 +72,17 @@ def show_configure_author_dialog(
     layout = QtWidgets.QVBoxLayout(dialog)
     layout.addWidget(
         QtWidgets.QLabel(
-            translate(
-                "History",
-                "Enter the name and email you'd like to use for your git identity, "
-                "which is used for authoring project iterations.",
+            term(
+                translate(
+                    "History",
+                    "Enter the name and email you'd like to use for your git identity, "
+                    "which is used for authoring project iterations.",
+                ),
+                translate(
+                    "History",
+                    "Enter the name and email you'd like to use for your git identity, "
+                    "which is used for authoring repository commits.",
+                ),
             ),
             dialog,
         )
@@ -84,7 +98,10 @@ def show_configure_author_dialog(
     name_edit = QtWidgets.QLineEdit(dialog)
     email_edit = QtWidgets.QLineEdit(dialog)
     remember_checkbox = QtWidgets.QCheckBox(
-        translate("History", "Configure globally for all projects"),
+        term(
+            translate("History", "Configure globally for all projects"),
+            translate("History", "Configure globally for all repositories"),
+        ),
         dialog,
     )
 
@@ -176,9 +193,17 @@ def show_restore_scope_dialog(parent: QtWidgets.QWidget) -> str | None:
     layout.addWidget(title_label)
     listed = QtWidgets.QRadioButton(translate("History", "Listed FreeCAD files"))
     listed_desc = QtWidgets.QLabel(
-        translate(
-            "History",
-            "Restore only the FreeCAD files changed in the selected iteration. Other files on disk are left unchanged.",
+        term(
+            translate(
+                "History",
+                "Restore only the FreeCAD files changed in the selected iteration. "
+                "Other files on disk are left unchanged.",
+            ),
+            translate(
+                "History",
+                "Restore only the FreeCAD files changed in the selected commit. "
+                "Other files on disk are left unchanged.",
+            ),
         )
     )
     listed_desc.setWordWrap(True)
@@ -245,15 +270,24 @@ def show_init_repository_dialog(
 ) -> str | None:
     """Show repository initialization dialog and return selected directory."""
     dialog = QtWidgets.QDialog(parent)
-    dialog.setWindowTitle(translate("History", "Initialize Project"))
+    dialog.setWindowTitle(
+        term(translate("History", "Initialize Project"), translate("History", "Initialize Repository"))
+    )
     dialog.setSizeGripEnabled(True)
     layout = QtWidgets.QVBoxLayout(dialog)
     layout.addWidget(
         QtWidgets.QLabel(
-            translate(
-                "History",
-                "Choose a directory to initialize based on currently open documents. "
-                "The selected directory will be the root of your project:",
+            term(
+                translate(
+                    "History",
+                    "Choose a directory to initialize based on currently open documents. "
+                    "The selected directory will be the root of your project:",
+                ),
+                translate(
+                    "History",
+                    "Choose a directory to initialize based on currently open documents. "
+                    "The selected directory will be the root of your repository:",
+                ),
             )
         )
     )
@@ -272,7 +306,10 @@ def show_init_repository_dialog(
 
         if not candidate.is_available:
             reason_label = QtWidgets.QLabel(
-                translate("History", "Already inside project"),
+                term(
+                    translate("History", "Already inside project"),
+                    translate("History", "Already inside repository"),
+                ),
                 dialog,
             )
             reason_label.setEnabled(False)
@@ -284,7 +321,10 @@ def show_init_repository_dialog(
     if first_available_button is not None:
         first_available_button.setChecked(True)
     else:
-        no_available_text = translate("History", "All listed directories are already inside projects.")
+        no_available_text = term(
+            translate("History", "All listed directories are already inside projects."),
+            translate("History", "All listed directories are already inside repositories."),
+        )
         layout.addWidget(QtWidgets.QLabel(no_available_text))
 
     button_layout = QtWidgets.QHBoxLayout()
@@ -316,7 +356,7 @@ def show_init_repository_dialog(
 def show_gitignore_editor_dialog(parent: QtWidgets.QWidget, content: str) -> str | None:
     """Show gitignore editor dialog. Returns edited content on accept, None on cancel."""
     dialog = QtWidgets.QDialog(parent)
-    dialog.setWindowTitle(translate("History", "Edit Ignored Files"))
+    dialog.setWindowTitle(term(translate("History", "Edit Ignored Files"), translate("History", "Edit .gitignore")))
     dialog.setMinimumWidth(680)
     dialog.setMinimumHeight(460)
 

--- a/freecad/history_wb/ui/views/document_diff/document_row.py
+++ b/freecad/history_wb/ui/views/document_diff/document_row.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from functools import partial
 
 from ....qt import QtCore, QtWidgets
-from ....utils import translate
+from ....utils import term, translate
 from ...presenters.presentation_models import DiffTreePresentation
 from ..history.models import HistorySelection
 from ..widgets.buttons import make_row_action_button
@@ -16,11 +16,19 @@ from .status_indicators import DocumentStatusIndicatorsWidget
 STAGE_BUTTON_WIDTH = 90
 REMOVE_BUTTON_WIDTH = 90
 RESTORE_BUTTON_WIDTH = 90
-REMOVE_REVIEWED_TOOLTIP = translate(
-    "History",
-    "Remove document(s) from Reviewed.\n"
-    "The current file(s) stay unchanged.\n"
-    "They will not be saved in the next iteration until reviewed again.",
+REMOVE_REVIEWED_TOOLTIP = term(
+    translate(
+        "History",
+        "Remove document(s) from Reviewed.\n"
+        "The current file(s) stay unchanged.\n"
+        "They will not be saved in the next iteration until reviewed again.",
+    ),
+    translate(
+        "History",
+        "Remove document(s) from Staged.\n"
+        "The current file(s) stay unchanged.\n"
+        "They will not be saved in the next commit until staged again.",
+    ),
 )
 
 
@@ -98,7 +106,7 @@ class DocumentDiffRowWidget(QtWidgets.QWidget):
     def _add_stage_button(self, layout: QtWidgets.QHBoxLayout) -> None:
         """Add + Reviewed button for one working-tree document row."""
         self._stage_button = make_row_action_button(
-            text=translate("History", "+ Reviewed"),
+            text=term(translate("History", "+ Reviewed"), translate("History", "+ Staged")),
             width=STAGE_BUTTON_WIDTH,
             on_clicked=partial(self.stage_requested.emit, self._diff.git_path),
         )
@@ -117,12 +125,21 @@ class DocumentDiffRowWidget(QtWidgets.QWidget):
 
     def _add_restore_button(self, layout: QtWidgets.QHBoxLayout) -> None:
         """Add Restore button for reviewed or commit-backed document rows."""
-        tooltip = translate(
-            "History",
-            "Restore the selected file.\n"
-            "This overwrites %1 on disk with a copy of the file as it was saved in the selected iteration.\n"
-            "THE CURRENT FILE WILL BE OVERWRITTEN BY THIS OPERATION.\n"
-            "Saved history will not be affected.",
+        tooltip = term(
+            translate(
+                "History",
+                "Restore the selected file.\n"
+                "This overwrites %1 on disk with a copy of the file as it was saved in the selected iteration.\n"
+                "THE CURRENT FILE WILL BE OVERWRITTEN BY THIS OPERATION.\n"
+                "Saved history will not be affected.",
+            ),
+            translate(
+                "History",
+                "Restore the selected file.\n"
+                "This overwrites %1 on disk with a copy of the file as it was saved in the selected commit.\n"
+                "THE CURRENT FILE WILL BE OVERWRITTEN BY THIS OPERATION.\n"
+                "Saved history will not be affected.",
+            ),
         ).replace("%1", self._top_level_text)
         restore_button = make_row_action_button(
             text=translate("History", "Restore"),

--- a/freecad/history_wb/ui/views/document_diff/node_row.py
+++ b/freecad/history_wb/ui/views/document_diff/node_row.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from ....qt import QtCore, QtGui, QtWidgets
 from ....resources import get_icon_path
-from ....utils import translate
+from ....utils import term, translate
 from ..widgets.buttons import make_tool_button
 from ..widgets.styles import (
     DIFF_ROW_CONTAINER_OBJECT_NAME,
@@ -54,7 +54,7 @@ class NodeDiffRowWidget(QtWidgets.QWidget):
 
         icon_size = QtCore.QSize(TREE_ITEM_ICON_SIZE, TREE_ITEM_ICON_SIZE)
         button = make_tool_button(
-            tooltip=translate("History", "Open 3D comparison"),
+            tooltip=term(translate("History", "Open 3D comparison"), translate("History", "Open 3D diff")),
             icon=QtGui.QIcon(str(get_icon_path("VisualDiff.svg"))),
             width=TREE_ITEM_HEIGHT,
             height=TREE_ITEM_HEIGHT,
@@ -63,7 +63,5 @@ class NodeDiffRowWidget(QtWidgets.QWidget):
             icon_size=icon_size,
             tool_button_style=QtCore.Qt.ToolButtonStyle.ToolButtonIconOnly,
         )
-        button.clicked.connect(
-            lambda checked=False: self.visual_diff_requested.emit(self._git_path, self._node_path)
-        )
+        button.clicked.connect(lambda checked=False: self.visual_diff_requested.emit(self._git_path, self._node_path))
         layout.addWidget(button)

--- a/freecad/history_wb/ui/views/document_diff/summary_bar.py
+++ b/freecad/history_wb/ui/views/document_diff/summary_bar.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from ....qt import QtCore, QtGui, QtWidgets
 from ....resources import get_icon_path
-from ....utils import translate
+from ....utils import term, translate
 from ..widgets.buttons import make_tool_button
 from ..widgets.styles import TREE_ITEM_HEIGHT
 from .summary_state import SummaryButtonState, SummaryCounts
@@ -53,7 +53,7 @@ class DocumentDiffSummaryBar(QtWidgets.QWidget):
         layout.addLayout(self._summary_layout)
 
         self._stage_all_button = make_tool_button(
-            text=translate("History", "+ Mark All Reviewed"),
+            text=term(translate("History", "+ Mark All Reviewed"), translate("History", "+ Mark All Staged")),
             width=STAGE_ALL_BUTTON_WIDTH,
             height=TREE_ITEM_HEIGHT,
         )
@@ -64,11 +64,19 @@ class DocumentDiffSummaryBar(QtWidgets.QWidget):
 
         self._restore_all_button = make_tool_button(
             text=translate("History", "Restore All"),
-            tooltip=translate(
-                "History",
-                "Choose which files to restore from the selected iteration.\n"
-                "Current files on disk can be overwritten or removed.\n"
-                "Saved history will not be affected.",
+            tooltip=term(
+                translate(
+                    "History",
+                    "Choose which files to restore from the selected iteration.\n"
+                    "Current files on disk can be overwritten or removed.\n"
+                    "Saved history will not be affected.",
+                ),
+                translate(
+                    "History",
+                    "Choose which files to restore from the selected commit.\n"
+                    "Current files on disk can be overwritten or removed.\n"
+                    "Saved history will not be affected.",
+                ),
             ),
             height=TREE_ITEM_HEIGHT,
         )

--- a/freecad/history_wb/ui/views/history/history_list.py
+++ b/freecad/history_wb/ui/views/history/history_list.py
@@ -3,7 +3,7 @@
 from typing import cast
 
 from ....qt import QtCore, QtGui, QtWidgets
-from ....utils import translate
+from ....utils import term, translate
 from .models import HistorySelection
 
 
@@ -138,7 +138,9 @@ class HistoryList(QtWidgets.QListWidget):
         """Show Current Files Area bulk-review context action."""
         menu = QtWidgets.QMenu(self)
         menu.setToolTipsVisible(True)
-        action = menu.addAction(translate("History", "Mark All Files Reviewed"))
+        action = menu.addAction(
+            term(translate("History", "Mark All Files Reviewed"), translate("History", "Mark All Files Staged"))
+        )
         selected_action = menu.exec(self.mapToGlobal(pos))
 
         if selected_action == action:
@@ -146,15 +148,29 @@ class HistoryList(QtWidgets.QListWidget):
 
     def _show_reviewed_context_menu(self, pos: QtCore.QPoint, selection: HistorySelection) -> None:
         """Show Reviewed Area context menu actions."""
-        tooltip = translate(
-            "History",
-            "Remove document(s) from Reviewed. The current file(s) stay unchanged "
-            "and will not be saved in the next iteration until reviewed again.",
+        tooltip = term(
+            translate(
+                "History",
+                "Remove document(s) from Reviewed. The current file(s) stay unchanged "
+                "and will not be saved in the next iteration until reviewed again.",
+            ),
+            translate(
+                "History",
+                "Remove document(s) from Staged. The current file(s) stay unchanged "
+                "and will not be saved in the next commit until staged again.",
+            ),
         )
         menu = QtWidgets.QMenu(self)
         menu.setToolTipsVisible(True)
-        action = menu.addAction(translate("History", "Remove All Files From Reviewed"))
-        restore_action = menu.addAction(translate("History", "Restore All Reviewed Files"))
+        action = menu.addAction(
+            term(
+                translate("History", "Remove All Files From Reviewed"),
+                translate("History", "Remove All Files From Staged"),
+            )
+        )
+        restore_action = menu.addAction(
+            term(translate("History", "Restore All Reviewed Files"), translate("History", "Restore All Staged Files"))
+        )
         action.setToolTip(tooltip)
         action.setStatusTip(tooltip)
         selected_action = menu.exec(self.mapToGlobal(pos))
@@ -168,8 +184,18 @@ class HistoryList(QtWidgets.QListWidget):
     def _show_commit_context_menu(self, pos: QtCore.QPoint, selection: HistorySelection) -> None:
         """Show commit-row context actions."""
         menu = QtWidgets.QMenu(self)
-        restore_action = menu.addAction(translate("History", "Restore All Files From Iteration"))
-        copy_id_action = menu.addAction(translate("History", "Copy Iteration ID to Clipboard"))
+        restore_action = menu.addAction(
+            term(
+                translate("History", "Restore All Files From Iteration"),
+                translate("History", "Restore All Files From Commit"),
+            )
+        )
+        copy_id_action = menu.addAction(
+            term(
+                translate("History", "Copy Iteration ID to Clipboard"),
+                translate("History", "Copy Commit ID to Clipboard"),
+            )
+        )
         selected_action = menu.exec(self.mapToGlobal(pos))
 
         if selected_action == restore_action:

--- a/freecad/history_wb/ui/views/history/panel.py
+++ b/freecad/history_wb/ui/views/history/panel.py
@@ -1,10 +1,11 @@
 """File responsibility: History panel facade composing repository header and history list."""
+
 from datetime import datetime
 
 from ....application.actions.result_models import SnapshotSummary
 from ....domain.git.models import GitCommit, GitRepository
 from ....qt import QtCore, QtWidgets
-from ....utils import translate
+from ....utils import term, translate
 from .formatters import format_snapshot_timestamp
 from .history_list import HistoryList
 from .history_row import create_commit_history_item, create_no_iterations_history_item, create_special_history_item
@@ -59,7 +60,10 @@ class HistoryPanelWidget(QtWidgets.QWidget):
             self._add_special_items()
 
         if not show_special_items and not commits:
-            no_iterations_text = translate("History", "No iterations to display.")
+            no_iterations_text = term(
+                translate("History", "No iterations to display."),
+                translate("History", "No commits to display."),
+            )
             item, widget = create_no_iterations_history_item(no_iterations_text)
             self._add_list_item(item, widget)
             self._restore_history_selection(previous_selection)
@@ -88,7 +92,9 @@ class HistoryPanelWidget(QtWidgets.QWidget):
         self._repository_header = RepositoryHeader(self)
         self._history_list = HistoryList(self)
 
-        history_placeholder = QtWidgets.QLabel(translate("History", "Iterations"))
+        history_placeholder = QtWidgets.QLabel(
+            term(translate("History", "Iterations"), translate("History", "Commits"))
+        )
         history_placeholder.setAlignment(QtCore.Qt.AlignmentFlag.AlignLeft)
 
         layout = QtWidgets.QVBoxLayout(self)
@@ -135,13 +141,13 @@ class HistoryPanelWidget(QtWidgets.QWidget):
     def _add_special_items(self) -> None:
         """Insert Current Files Area and Reviewed Area pseudo-rows."""
         working_tree_item, working_tree_widget = create_special_history_item(
-            translate("History", "Current Files Area"),
+            term(translate("History", "Current Files Area"), translate("History", "Working Tree")),
             HistorySelection(item_kind="WORKING_TREE", commit_hash=None),
         )
         self._add_list_item(working_tree_item, working_tree_widget)
 
         staging_item, staging_widget = create_special_history_item(
-            translate("History", "Reviewed Area"),
+            term(translate("History", "Reviewed Area"), translate("History", "Staging Area")),
             HistorySelection(item_kind="STAGING", commit_hash=None),
         )
         self._add_list_item(staging_item, staging_widget)

--- a/freecad/history_wb/ui/views/history/repository_header.py
+++ b/freecad/history_wb/ui/views/history/repository_header.py
@@ -5,7 +5,7 @@ from collections.abc import Callable
 from ....domain.git.models import GitRepository
 from ....qt import QtCore, QtGui, QtWidgets
 from ....resources import get_icon_path
-from ....utils import translate
+from ....utils import term, translate
 from ..widgets.buttons import make_tool_button
 from ..widgets.styles import HEADER_ICON_BUTTON_STYLE, REPOSITORY_LABEL_EMPTY_STYLE, REPOSITORY_LABEL_LINK_STYLE
 
@@ -60,14 +60,18 @@ class RepositoryHeader(QtWidgets.QWidget):
         # Null repository means workbench currently has no project context.
         if repo is None:
             self._current_repository_path = None
-            self._repository_label.setText(translate("History", "No project detected"))
+            self._repository_label.setText(
+                term(translate("History", "No project detected"), translate("History", "No repository detected"))
+            )
             self._repository_label.setToolTip("")
             self._repository_label.setCursor(QtCore.Qt.CursorShape.ArrowCursor)
             self._repository_label.setStyleSheet(REPOSITORY_LABEL_EMPTY_STYLE)
             return
 
         self._current_repository_path = repo.absolute_path
-        text = translate("History", "Project: %1").replace("%1", repo.name)
+        text = term(translate("History", "Project: %1"), translate("History", "Repository: %1")).replace(
+            "%1", repo.name
+        )
         self._repository_label.setText(text)
         self._repository_label.setToolTip(repo.absolute_path)
         self._repository_label.setCursor(QtCore.Qt.CursorShape.PointingHandCursor)
@@ -80,7 +84,10 @@ class RepositoryHeader(QtWidgets.QWidget):
         self._repository_label.setStyleSheet(REPOSITORY_LABEL_EMPTY_STYLE)
 
         self._refresh_button = make_tool_button(
-            tooltip=translate("History", "Refresh Project and Iterations"),
+            tooltip=term(
+                translate("History", "Refresh Project and Iterations"),
+                translate("History", "Refresh Repository and Commits"),
+            ),
             style=HEADER_ICON_BUTTON_STYLE,
             icon_size=QtCore.QSize(24, 24),
             tool_button_style=QtCore.Qt.ToolButtonStyle.ToolButtonIconOnly,
@@ -90,7 +97,7 @@ class RepositoryHeader(QtWidgets.QWidget):
         self._refresh_button.clicked.connect(self.refresh_requested.emit)
 
         self._save_iteration_button = make_tool_button(
-            tooltip=translate("History", "Save Iteration"),
+            tooltip=term(translate("History", "Save Iteration"), translate("History", "Commit")),
             style=HEADER_ICON_BUTTON_STYLE,
             icon_size=QtCore.QSize(24, 24),
             tool_button_style=QtCore.Qt.ToolButtonStyle.ToolButtonIconOnly,

--- a/freecad/history_wb/ui/views/settings_preferences_page.py
+++ b/freecad/history_wb/ui/views/settings_preferences_page.py
@@ -20,7 +20,7 @@ from ...domain.settings.text_codec import (
     serialize_list_lines,
 )
 from ...qt import QtWidgets
-from ...utils import Log, translate
+from ...utils import Log, git_terminology_enabled, set_git_terminology_enabled, translate
 
 
 @dataclass(frozen=True)
@@ -116,6 +116,24 @@ class DiffSettingsPreferencesPage:
         precision_group = QtWidgets.QGroupBox(translate("History", "Numeric comparison"), self.form)
         precision_group.setLayout(precision_layout)
         root_layout.addWidget(precision_group)
+
+        self._git_terminology_checkbox = QtWidgets.QCheckBox(
+            translate("History", "Use git terminology (Commit, Repository, Staged, …)"),
+            self.form,
+        )
+        self._git_terminology_checkbox.setToolTip(
+            translate(
+                "History",
+                "Relabel the interface with the underlying git terms instead of the "
+                "CAD-friendly defaults. Takes full effect after restarting FreeCAD.",
+            )
+        )
+        terminology_layout = QtWidgets.QVBoxLayout()
+        terminology_layout.addWidget(self._git_terminology_checkbox)
+        terminology_group = QtWidgets.QGroupBox(translate("History", "Terminology"), self.form)
+        terminology_group.setLayout(terminology_layout)
+        root_layout.addWidget(terminology_group)
+
         root_layout.addStretch(1)
 
         self._excluded_types_default_radio = self._excluded_types_controls.default_radio
@@ -147,6 +165,7 @@ class DiffSettingsPreferencesPage:
         self._apply_list_state(self._excluded_properties_controls, state.excluded_properties)
         self._apply_by_type_state(self._excluded_by_type_controls, state.excluded_properties_by_type)
         self._float_precision_spin.setValue(state.float_precision)
+        self._git_terminology_checkbox.setChecked(git_terminology_enabled())
         self._is_loading = False
         self._sync_visibility()
 
@@ -173,6 +192,8 @@ class DiffSettingsPreferencesPage:
             Log.error(result.message or "Failed to save diff settings state")
             return
         self._loaded_state = state_to_save
+        # Terminology preference is independent of the diff Settings model.
+        set_git_terminology_enabled(self._git_terminology_checkbox.isChecked())
 
     def _bind_signals(self) -> None:
         self._excluded_types_controls.custom_radio.toggled.connect(

--- a/freecad/history_wb/utils.py
+++ b/freecad/history_wb/utils.py
@@ -6,9 +6,12 @@ and translation helper for FreeCAD UI text.
 """
 
 import traceback
-from typing import Protocol
+from typing import Protocol, TypeVar
 
 from .qt import QtCore
+
+
+_Term = TypeVar("_Term")
 
 
 class LoggerProtocol(Protocol):
@@ -215,6 +218,42 @@ def translate(context: str, text: str) -> str:
         return text
 
 
+def git_terminology_enabled() -> bool:
+    """Return whether the git-native terminology display toggle is on.
+
+    Resolves through the application container's cached settings repository.
+    Command labels are built at workbench Initialize, before the container
+    exists; in that case the toggle is read directly from FreeCAD preferences.
+    """
+    from ._container import get_container
+
+    try:
+        return get_container().settings_repo.git_terminology_enabled()
+    except RuntimeError:
+        # Container not built yet (e.g. command registration at Initialize).
+        from .infrastructure.freecad.settings_repo import read_git_terminology_enabled
+
+        return read_git_terminology_enabled()
+
+
+def set_git_terminology_enabled(enabled: bool) -> None:
+    """Persist the git-native terminology display toggle."""
+    from ._container import get_container
+
+    get_container().settings_repo.set_git_terminology_enabled(enabled)
+
+
+def term(cad: _Term, git: _Term) -> _Term:
+    """Pick the git-native phrase when the terminology toggle is on, else CAD.
+
+    Both arguments must be passed as the result of ``translate(...)`` or
+    ``QT_TRANSLATE_NOOP(...)`` literals so translation extraction (lupdate)
+    still records both variants. Generic so it preserves ``str`` from
+    ``translate()`` and the ``object`` returned by ``QT_TRANSLATE_NOOP``.
+    """
+    return git if git_terminology_enabled() else cad
+
+
 __all__ = [
     "LoggerProtocol",
     "StdoutLogger",
@@ -224,4 +263,7 @@ __all__ = [
     "format_float",
     "float_values_equal",
     "translate",
+    "git_terminology_enabled",
+    "set_git_terminology_enabled",
+    "term",
 ]

--- a/tests/unit/entrypoints/test_open_all_documents_command.py
+++ b/tests/unit/entrypoints/test_open_all_documents_command.py
@@ -22,6 +22,7 @@ class TestOpenAllDocumentsInRepositoryCommand:
         """When no repository in UI state, warning popup is shown."""
         mock_container = MagicMock()
         mock_container.translate.side_effect = lambda _ctx, text: text
+        mock_container.settings_repo.git_terminology_enabled.return_value = False
         mock_get_container.return_value = mock_container
         mock_ui_registry.application_state.git_repository = None
 

--- a/tests/unit/infrastructure/freecad/test_settings_repo.py
+++ b/tests/unit/infrastructure/freecad/test_settings_repo.py
@@ -11,6 +11,7 @@ from freecad.history_wb.domain.config import (
 )
 from freecad.history_wb.domain.freecad_ports import FreeCadContext
 from freecad.history_wb.infrastructure.freecad.settings_repo import (
+    KEY_GIT_TERMINOLOGY,
     MAX_FLOAT_PRECISION,
     MIN_FLOAT_PRECISION,
     FreeCADSettingsRepository,
@@ -80,6 +81,31 @@ class TestFreeCADSettingsRepository:
         assert settings.excluded_properties == EXCLUDED_PROPERTIES
         assert settings.excluded_properties_by_type == EXCLUDED_PROPERTIES_BY_TYPE
         assert settings.float_precision == FLOAT_PRECISION
+
+    def test_git_terminology_defaults_to_disabled(self) -> None:
+        repo, _ = _make_repo()
+
+        assert repo.git_terminology_enabled() is False
+
+    def test_set_git_terminology_persists_and_reads_back(self) -> None:
+        repo, group = _make_repo()
+
+        repo.set_git_terminology_enabled(True)
+
+        assert group.GetBool(KEY_GIT_TERMINOLOGY, False) is True
+        assert repo.git_terminology_enabled() is True
+
+    def test_git_terminology_is_cached_until_set(self) -> None:
+        repo, group = _make_repo()
+
+        # First read caches the default; a direct param change is not observed.
+        assert repo.git_terminology_enabled() is False
+        group.SetBool(KEY_GIT_TERMINOLOGY, True)
+        assert repo.git_terminology_enabled() is False
+
+        # set refreshes the cache.
+        repo.set_git_terminology_enabled(True)
+        assert repo.git_terminology_enabled() is True
 
     def test_custom_mode_returns_parsed_line_values(self) -> None:
         repo, group = _make_repo()

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,10 +1,12 @@
-# File responsibility: Unit tests for float comparison helper functions.
+# File responsibility: Unit tests for utility helper functions.
 """Unit tests for utility functions in the Diff Workbench."""
+
+from unittest.mock import patch
 
 import pytest
 
 from freecad.history_wb.domain.config import FLOAT_PRECISION
-from freecad.history_wb.utils import float_values_equal
+from freecad.history_wb.utils import float_values_equal, term
 
 
 class TestFloatValuesEqual:
@@ -36,3 +38,15 @@ class TestFloatValuesEqual:
         """Test that float_values_equal uses the configured precision."""
         assert float_values_equal(1.0, 1.0 + 1e-8, FLOAT_PRECISION) is True
         assert float_values_equal(1.0, 1.1, FLOAT_PRECISION) is False
+
+
+class TestTerm:
+    """Tests for the git-terminology phrase selector."""
+
+    def test_returns_cad_phrase_when_disabled(self) -> None:
+        with patch("freecad.history_wb.utils.git_terminology_enabled", return_value=False):
+            assert term("Save Iteration", "Commit") == "Save Iteration"
+
+    def test_returns_git_phrase_when_enabled(self) -> None:
+        with patch("freecad.history_wb.utils.git_terminology_enabled", return_value=True):
+            assert term("Save Iteration", "Commit") == "Commit"

--- a/tests/unit/ui/views/test_settings_preferences_page.py
+++ b/tests/unit/ui/views/test_settings_preferences_page.py
@@ -4,6 +4,9 @@
 from __future__ import annotations
 
 from dataclasses import replace
+from unittest.mock import MagicMock, patch
+
+import pytest
 
 from freecad.history_wb.application.actions.result_models import Result
 from freecad.history_wb.domain.config import EXCLUDED_TYPES
@@ -61,6 +64,14 @@ def _ensure_qapplication() -> None:
 
 
 class TestDiffSettingsPreferencesPage:
+    @pytest.fixture(autouse=True)
+    def _fake_container(self):
+        """Provide a container so the git-terminology toggle read/write resolves."""
+        container = MagicMock()
+        container.settings_repo.git_terminology_enabled.return_value = False
+        with patch("freecad.history_wb._container.get_container", return_value=container):
+            yield container
+
     def test_preference_page_loads_current_mode_and_values_into_controls(self) -> None:
         _ensure_qapplication()
 


### PR DESCRIPTION
## Note:
Thanks for putting this together! Let me know if you need someone to wade through slop PRs, or help out with the project - I'd love to be involved.

## Claude:
 Adds an opt-in 'Use git terminology' preference that relabels the UI with the underlying git terms (Iteration->Commit, Project->Repository, Reviewed->Staged, Current Files->Working Tree, etc.).

- vocabulary.py: param-backed toggle + ordered, word-boundary friendly->git substitution (terms with no git analog, e.g. Snapshot, pass through).
- utils.translate(): routes runtime strings through the remap (central, no-op when disabled).
- commands.py: _LocalizedCommand wraps GetResources so QT_TRANSLATE_NOOP menu labels (which bypass translate()) are remapped too.
- preferences page: 'Use git terminology' checkbox under a Terminology group.
- tests: 15 cases covering mapping, longest-match, word boundaries, no-op.